### PR TITLE
Add top test times to pytest report

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -37,4 +37,4 @@ jobs:
         make clean compile
     - name: Test with pytest
       run: |
-        python -m pytest --cov=ecoli -m 'not (noci or master)'
+        python -m pytest --cov=ecoli --durations=0 -m 'not (noci or master)'

--- a/.github/workflows/pytest_master.yml
+++ b/.github/workflows/pytest_master.yml
@@ -30,4 +30,4 @@ jobs:
         make clean compile
     - name: Test with pytest
       run: |
-        python -m pytest --cov=ecoli -m master
+        python -m pytest --cov=ecoli --durations=0 -m master

--- a/ecoli/library/cell_wall/hole_detection.py
+++ b/ecoli/library/cell_wall/hole_detection.py
@@ -369,6 +369,7 @@ def test_detect_holes():
     print()
 
 
+@pytest.mark.skip(reason="Used locally to compare skimage and hand-rolled algo.")
 def test_runtime():
     # Runtime plot
     fig, axs = plt.subplots(nrows=4, ncols=1)


### PR DESCRIPTION
Our pytest times have recently begun to balloon out of control. This PR adds a flag to report the time spent in the most time-consuming tests and skips an unnecessary runtime comparison.