### PR TITLE
Make simulations deterministic

### DIFF
--- a/ecoli/library/pymunk_multibody.py
+++ b/ecoli/library/pymunk_multibody.py
@@ -32,25 +32,25 @@ def corner_from_center(width, length, center_position, angle):
     return np.array([corner_position[0], corner_position[1], angle])
 
 
-def random_body_position(body):
+def random_body_position(body, rng):
     ''' pick a random point along the boundary'''
     width, length = body.dimensions
-    if random.randint(0, 1) == 0:
+    if rng.integers(0, 2) == 0:
         # force along ends
-        if random.randint(0, 1) == 0:
+        if rng.integers(0, 2) == 0:
             # force on the left end
-            location = (random.uniform(0, width), 0)
+            location = (rng.uniform(0, width), 0)
         else:
             # force on the right end
-            location = (random.uniform(0, width), length)
+            location = (rng.uniform(0, width), length)
     else:
         # force along length
-        if random.randint(0, 1) == 0:
+        if rng.integers(0, 2) == 0:
             # force on the bottom end
-            location = (0, random.uniform(0, length))
+            location = (0, rng.uniform(0, length))
         else:
             # force on the top end
-            location = (width, random.uniform(0, length))
+            location = (width, rng.uniform(0, length))
     return location
 
 
@@ -82,9 +82,14 @@ class PymunkMultibody(object):
         'initial_agents': {},
         # for debugging
         'screen': None,
+        'seed': 0,
     }
 
     def __init__(self, config):
+        # PRNG for jitter force
+        self.rng = np.random.default_rng(
+            seed=config.get('seed', self.defaults['seed']))
+
         # hardcoded parameters
         self.elasticity = self.defaults['elasticity']
         self.friction = self.defaults['friction']
@@ -158,10 +163,10 @@ class PymunkMultibody(object):
         body.apply_impulse_at_local_point(scaled_motile_force, motile_location)
 
     def apply_jitter_force(self, body):
-        jitter_location = random_body_position(body)
+        jitter_location = random_body_position(body, self.rng)
         jitter_force = [
-            random.normalvariate(0, self.jitter_force),
-            random.normalvariate(0, self.jitter_force)]
+            self.rng.normal(0, self.jitter_force),
+            self.rng.normal(0, self.jitter_force)]
         scaled_jitter_force = [
             force * self.force_scaling
             for force in jitter_force]

--- a/ecoli/processes/chemotaxis/flagella_motor.py
+++ b/ecoli/processes/chemotaxis/flagella_motor.py
@@ -23,7 +23,6 @@ import os
 import copy
 import random
 import math
-import uuid
 
 import numpy as np
 
@@ -32,6 +31,7 @@ from vivarium.core.composition import simulate_process, PROCESS_OUT_DIR
 from vivarium.core.emitter import timeseries_from_data
 from vivarium.plots.simulation_output import plot_simulation_output
 
+from ecoli.library.schema import create_unique_indexes
 # plots
 from ecoli.plots.flagella_activity import plot_activity
 
@@ -102,11 +102,16 @@ class FlagellaMotor(Process):
                 'thrust': 0,
                 'torque': 0,
             }
-        }
+        },
+
+        # seed for unique ID generation
+        'seed': 0,
     }
 
     def __init__(self, parameters=None):
         super().__init__(parameters)
+        self.random_state = np.random.RandomState(
+            seed=self.parameters['seed'])
 
     def ports_schema(self):
         ports = [
@@ -212,8 +217,10 @@ class FlagellaMotor(Process):
 
         elif new_flagella > 0:
             flagella_update['_add'] = []
+            new_flagella_indexes = create_unique_indexes(
+                new_flagella, self.random_state)
             for index in range(new_flagella):
-                flagella_id = str(uuid.uuid1())
+                flagella_id = new_flagella_indexes[index]
                 flagella_update['_add'].append({
                     'key': flagella_id,
                     'state': random.choice([-1, 1])})

--- a/ecoli/processes/environment/multibody_physics.py
+++ b/ecoli/processes/environment/multibody_physics.py
@@ -123,6 +123,7 @@ class Multibody(Process):
         'boundary_key': 'boundary',
         'mother_machine': False,
         'animate': False,
+        'seed': 0,
     }
 
     def __init__(self, parameters=None):
@@ -150,6 +151,7 @@ class Multibody(Process):
             'bounds': remove_units(self.bounds),
             'barriers': self.mother_machine,
             'physics_dt': self.parameters['timestep'] / 10,
+            'seed': self.parameters['seed']
         }
         self.physics = PymunkMultibody(multibody_config)
 


### PR DESCRIPTION
This ensures that jitter force calculations are performed using a Numpy PRNG that can be seeded. This also updates `chromosome_replication.py` and `flagella_motor.py` to use the deterministic `create_unique_indexes` method in `schema.py`. Simulations should now be repeatable (tested locally up to 3500 seconds, which includes one round of division).