### PR TITLE
Media ID Timeline

### DIFF
--- a/ecoli/composites/chemotaxis_minimal.py
+++ b/ecoli/composites/chemotaxis_minimal.py
@@ -72,7 +72,7 @@ class ChemotaxisMinimal(Composer):
 
 
 
-def test_chemotaxis_minimal(total_time=10):
+def test_chemotaxis_minimal(total_time=10, return_timeseries=False):
     environment_port = ('external',)
     ligand_id = 'MeAsp'
     initial_conc = 0
@@ -106,7 +106,8 @@ def test_chemotaxis_minimal(total_time=10):
         'total_time': total_time}
     timeseries = simulate_composite(composite, experiment_settings)
 
-    return timeseries
+    if return_timeseries:
+        return timeseries
 
 
 def main():
@@ -115,7 +116,7 @@ def main():
         os.makedirs(out_dir)
 
     # run the composite
-    timeseries = test_chemotaxis_minimal(total_time=60)
+    timeseries = test_chemotaxis_minimal(total_time=60, return_timeseries=True)
 
     # plot
     plot_settings = {

--- a/ecoli/composites/ecoli_configs/default.json
+++ b/ecoli/composites/ecoli_configs/default.json
@@ -44,6 +44,9 @@
     "swap_processes" : {},
     "profile": false,
     "processes": [
+        "bulk-timeline",
+        "exchange_data",
+
         "ecoli-tf-unbinding",
 
         "ecoli-equilibrium",
@@ -80,9 +83,17 @@
     "process_configs": {
         "global_clock": {"time_step": 1},
         "replication_data_listener": {"time_step": 1}},
-    "topology": {},
+    "topology": {
+        "bulk-timeline": {
+            "bulk": ["bulk"],
+            "global": ["timeline"],
+            "media_id": ["environment", "media_id"]
+        }
+    },
     "flow": {
-        "ecoli-tf-unbinding": [],
+        "exchange_data": [],
+
+        "ecoli-tf-unbinding": [["exchange_data"]],
 
         "ecoli-equilibrium": [["ecoli-tf-unbinding"]],
         "ecoli-two-component-system": [["ecoli-tf-unbinding"]],

--- a/ecoli/composites/ecoli_configs/default.json
+++ b/ecoli/composites/ecoli_configs/default.json
@@ -89,6 +89,10 @@
             "bulk": ["bulk"],
             "global": ["timeline"],
             "media_id": ["environment", "media_id"]
+        },
+        "global_clock": {
+            "global_time": ["global_time"],
+            "timestep": ["timestep"]
         }
     },
     "flow": {

--- a/ecoli/composites/ecoli_configs/default.json
+++ b/ecoli/composites/ecoli_configs/default.json
@@ -45,6 +45,7 @@
     "profile": false,
     "processes": [
         "bulk-timeline",
+        "media_update",
         "exchange_data",
 
         "ecoli-tf-unbinding",
@@ -91,9 +92,10 @@
         }
     },
     "flow": {
-        "exchange_data": [],
+        "media_update": [],
+        "exchange_data": [["media_update"]],
 
-        "ecoli-tf-unbinding": [["exchange_data"]],
+        "ecoli-tf-unbinding": [["media_update"]],
 
         "ecoli-equilibrium": [["ecoli-tf-unbinding"]],
         "ecoli-two-component-system": [["ecoli-tf-unbinding"]],

--- a/ecoli/composites/ecoli_configs/fba_redux.json
+++ b/ecoli/composites/ecoli_configs/fba_redux.json
@@ -6,8 +6,6 @@
     },
     "exclude_processes": ["exchange_data"],
     "flow": {
-        "ecoli-tf-unbinding": [],
-
         "ecoli-metabolism-redux": [["ecoli-chromosome-structure"]],
         "ecoli-mass-listener": [["ecoli-metabolism-redux"]],
         "RNA_counts_listener": [["ecoli-metabolism-redux"]],

--- a/ecoli/composites/ecoli_configs/fba_redux.json
+++ b/ecoli/composites/ecoli_configs/fba_redux.json
@@ -4,7 +4,10 @@
     "swap_processes" : {
         "ecoli-metabolism" : "ecoli-metabolism-redux"
     },
+    "exclude_processes": ["exchange_data"],
     "flow": {
+        "ecoli-tf-unbinding": [],
+
         "ecoli-metabolism-redux": [["ecoli-chromosome-structure"]],
         "ecoli-mass-listener": [["ecoli-metabolism-redux"]],
         "RNA_counts_listener": [["ecoli-metabolism-redux"]],

--- a/ecoli/composites/ecoli_configs/fba_redux_div.json
+++ b/ecoli/composites/ecoli_configs/fba_redux_div.json
@@ -6,8 +6,6 @@
     },
     "exclude_processes": ["exchange_data"],
     "flow": {
-        "ecoli-tf-unbinding": [],
-
         "ecoli-metabolism-redux": [["ecoli-chromosome-structure"]],
         "ecoli-mass-listener": [["ecoli-metabolism-redux"]],
         "RNA_counts_listener": [["ecoli-metabolism-redux"]],

--- a/ecoli/composites/ecoli_configs/fba_redux_div.json
+++ b/ecoli/composites/ecoli_configs/fba_redux_div.json
@@ -4,7 +4,10 @@
     "swap_processes" : {
         "ecoli-metabolism" : "ecoli-metabolism-redux"
     },
+    "exclude_processes": ["exchange_data"],
     "flow": {
+        "ecoli-tf-unbinding": [],
+
         "ecoli-metabolism-redux": [["ecoli-chromosome-structure"]],
         "ecoli-mass-listener": [["ecoli-metabolism-redux"]],
         "RNA_counts_listener": [["ecoli-metabolism-redux"]],

--- a/ecoli/composites/ecoli_configs/test_configs/test_add_process.json
+++ b/ecoli/composites/ecoli_configs/test_configs/test_add_process.json
@@ -2,6 +2,7 @@
     "partition" : true,
     "experiment_id" : "test_add_process",
     "total_time" : 2,
+    "time_step": 2,
     "raw_output" : false,
     "_schema": {
         "clock" : {

--- a/ecoli/composites/ecoli_master.py
+++ b/ecoli/composites/ecoli_master.py
@@ -200,6 +200,8 @@ class Ecoli(Composer):
                 steps[process_name] = process
                 continue
             else:
+                if config['log_updates']:
+                    process_class = make_logging_process(process_class)
                 process = process_class(process_configs[process_name])
                 processes[process_name] = process
                 continue
@@ -398,13 +400,6 @@ class Ecoli(Composer):
 
         # Do not keep an unnecessary reference to these
         self.processes_and_steps = None
-
-        # Add clock process to facilitate unique molecule updates and
-        # coordinate simulation timestep updates
-        topology['global_clock'] = {
-            'global_time': ('global_time',),
-            'timestep': ('timestep',)
-        }
         return topology
 
 

--- a/ecoli/composites/ecoli_spatial.py
+++ b/ecoli/composites/ecoli_spatial.py
@@ -274,6 +274,7 @@ def add_polyribosomes(unique, unique_masses, polyribosome_assumption,
 def test_spatial_ecoli(
     polyribosome_assumption='spherical',    # choose from 'mrna', 'linear', or 'spherical'
     total_time=10,  # in seconds
+    return_data=False
 ):
     ecoli_config = {
         'nodes': {
@@ -322,7 +323,9 @@ def test_spatial_ecoli(
         'initial_state': ecoli.initial_state(initial_config)}
 
     data = simulate_composer(ecoli, settings)
-    return ecoli, initial_config, data
+
+    if return_data:
+        return ecoli, initial_config, data
 
 
 def run_spatial_ecoli(
@@ -331,6 +334,7 @@ def run_spatial_ecoli(
     ecoli, initial_config, output = test_spatial_ecoli(
         polyribosome_assumption=polyribosome_assumption,
         total_time=5*60,
+        return_data=True
     )
     mesh_size = ecoli.config['mesh_size']
     nodes = ecoli.config['nodes']

--- a/ecoli/composites/environment/grow_divide.py
+++ b/ecoli/composites/environment/grow_divide.py
@@ -113,7 +113,7 @@ class GrowDivideExchange(GrowDivide):
         return topology
 
 
-def test_grow_divide(total_time=2000):
+def test_grow_divide(total_time=2000, return_data=False):
 
     agent_id = '0'
     composite = GrowDivide({
@@ -148,10 +148,11 @@ def test_grow_divide(total_time=2000):
     assert len(output[0.0]['agents']) == 1
     assert len(output[total_time]['agents']) > 1
 
-    return output
+    if return_data:
+        return output
 
 
-def test_grow_divide_exchange(total_time=2000):
+def test_grow_divide_exchange(total_time=2000, return_data=False):
 
     agent_id = '0'
     molecule_id = 'A'
@@ -198,7 +199,8 @@ def test_grow_divide_exchange(total_time=2000):
     assert len(output[0.0]['agents']) == 1
     assert len(output[total_time]['agents']) > 1
 
-    return output
+    if return_data:
+        return output
 
 
 def main():
@@ -207,12 +209,12 @@ def main():
         os.makedirs(out_dir)
 
     # if grow_divide:
-    output = test_grow_divide(2000)
+    output = test_grow_divide(2000, return_data=True)
     plot_settings = {}
     plot_agents_multigen(output, plot_settings, out_dir, 'grow_divide')
 
     # if grow_divide_exchange:
-    output = test_grow_divide_exchange(2000)
+    output = test_grow_divide_exchange(2000, return_data=True)
     plot_settings = {}
     plot_agents_multigen(output, plot_settings, out_dir, 'grow_divide_exchange')
 

--- a/ecoli/composites/environment/lattice.py
+++ b/ecoli/composites/environment/lattice.py
@@ -141,6 +141,7 @@ def test_lattice(
         initial_field=None,
         growth_rate=0.05,  # fast growth
         growth_noise=5e-4,
+        return_data=False
 ):
     # lattice configuration
     lattice_config_kwargs = {
@@ -209,7 +210,8 @@ def test_lattice(
     # run the simulation
     spatial_experiment.update(total_time)
     data = spatial_experiment.emitter.get_data_unitless()
-    return data
+    if return_data:
+        return data
 
 
 def main():
@@ -230,7 +232,8 @@ def main():
             exchange=True,
             n_agents=n_agents,
             total_time=total_time,
-            bounds=bounds)
+            bounds=bounds,
+            return_data=True)
     else:
         # GrowDivide agents
         n_bins = [20, 20]
@@ -241,7 +244,8 @@ def main():
             total_time=total_time,
             bounds=bounds,
             n_bins=n_bins,
-            initial_field=initial_field)
+            initial_field=initial_field,
+            return_data=True)
 
     # format the data for plot_snapshots
     agents, fields = format_snapshot_data(data)

--- a/ecoli/experiments/ecoli_master_sim.py
+++ b/ecoli/experiments/ecoli_master_sim.py
@@ -361,12 +361,6 @@ class EcoliSim:
             for process, ports in result.items():
                 result[process]['log_update'] = ('log_update', process,)
 
-        # add division
-        if divide:
-            result['division'] = {
-                'variable': ('listeners', 'mass', 'dry_mass'),
-                'agents': self.agents_path}
-
         return result
 
 

--- a/ecoli/library/serialize.py
+++ b/ecoli/library/serialize.py
@@ -1,3 +1,4 @@
+import numpy as np
 import orjson
 import re
 from unum import Unum
@@ -15,7 +16,9 @@ class UnumSerializer(Serializer):
 
     python_type = Unum
     def serialize(self, value):
-        num = str(value.asNumber().tolist())
+        num = str(value.asNumber())
+        if isinstance(num, np.ndarray):
+            num = num.tolist()
         return f'!UnumSerializer[{num} | {value.strUnit()}]'
         
     def can_deserialize(self, data):

--- a/ecoli/library/sim_data.py
+++ b/ecoli/library/sim_data.py
@@ -400,6 +400,7 @@ class LoadSimData:
             'rnap_data_listener': self.get_rnap_data_listener_config,
             'unique_molecule_counts': self.get_unique_molecule_counts_config,
             'exchange_data': self.get_exchange_data_config,
+            'media_update': self.get_media_update_config,
             'bulk-timeline': self.get_bulk_timeline_config,
         }
 
@@ -1470,6 +1471,12 @@ class LoadSimData:
             '_parallel': parallel,
             'exchange_data_from_concentrations': self.sim_data.external_state.exchange_data_from_concentrations,
             'environment_molecules': list(self.sim_data.external_state.env_to_exchange_map.keys()),
+        }
+    
+    def get_media_update_config(self, time_step=1, parallel=False):
+        return {
+            'time_step': time_step,
+            '_parallel': parallel,
             'saved_media': self.sim_data.external_state.saved_media
         }
     

--- a/ecoli/library/sim_data.py
+++ b/ecoli/library/sim_data.py
@@ -399,6 +399,8 @@ class LoadSimData:
             'ribosome_data_listener': self.get_ribosome_data_listener_config,
             'rnap_data_listener': self.get_rnap_data_listener_config,
             'unique_molecule_counts': self.get_unique_molecule_counts_config,
+            'exchange_data': self.get_exchange_data_config,
+            'bulk-timeline': self.get_bulk_timeline_config,
         }
 
         try:
@@ -915,7 +917,6 @@ class LoadSimData:
             'aa_targets_not_updated': aa_targets_not_updated,
             'import_constraint_threshold': self.sim_data.external_state.import_constraint_threshold,
             'exchange_molecules': self.sim_data.external_state.all_external_exchange_molecules,
-            'exchange_data_from_concentrations': exch_from_conc,
             'imports': imports,
 
             # these are options given to the wholecell.sim.simulation
@@ -1033,7 +1034,6 @@ class LoadSimData:
             'aa_targets_not_updated': aa_targets_not_updated,
             'import_constraint_threshold': self.sim_data.external_state.import_constraint_threshold,
             'exchange_molecules': self.sim_data.external_state.all_external_exchange_molecules,
-            'exchange_data_from_concentrations': exch_from_conc,
 
             # these are options given to the wholecell.sim.simulation
             'use_trna_charging': self.trna_charging,
@@ -1464,6 +1464,31 @@ class LoadSimData:
             'emit_unique': self.emit_unique
         }
     
+    def get_exchange_data_config(self, time_step=1, parallel=False):
+        return {
+            'time_step': time_step,
+            '_parallel': parallel,
+            'exchange_data_from_concentrations': self.sim_data.external_state.exchange_data_from_concentrations,
+            'environment_molecules': list(self.sim_data.external_state.env_to_exchange_map.keys()),
+            'saved_media': self.sim_data.external_state.saved_media
+        }
+    
+    def get_bulk_timeline_config(self, time_step=1, parallel=False):
+        # if current_timeline_id is specified by a variant in sim_data, look it up in saved_timelines.
+        if self.sim_data.external_state.current_timeline_id:
+            current_timeline = self.sim_data.external_state.saved_timelines[
+                self.sim_data.external_state.current_timeline_id]
+        else:
+            current_timeline = self.media_timeline
+        return {
+            'time_step': time_step,
+            '_parallel': parallel,
+            'timeline': {
+                time: {('media_id',): media_id}
+                for time, media_id in current_timeline
+            }
+        }
+
     # def generate_initial_state(self):
     #     '''
     #     Calculate the initial conditions for a new cell without inherited state

--- a/ecoli/plots/snapshots_video.py
+++ b/ecoli/plots/snapshots_video.py
@@ -297,7 +297,8 @@ def main(total_time=2000, step=60, exchange=False):
         growth_noise=1e-3,
         bounds=bounds,
         n_bins=n_bins,
-        initial_field=initial_field)
+        initial_field=initial_field,
+        return_data=True)
 
     # make snapshot video
     make_video(

--- a/ecoli/processes/__init__.py
+++ b/ecoli/processes/__init__.py
@@ -31,6 +31,7 @@ from ecoli.processes.allocator import Allocator
 from ecoli.processes.environment.lysis import Lysis
 from ecoli.processes.environment.local_field import LocalField
 from ecoli.processes.environment.field_timeline import FieldTimeline
+from ecoli.processes.environment.exchange_data import ExchangeData
 from ecoli.processes.shape import Shape
 from ecoli.processes.antibiotics.cell_wall import CellWall
 from ecoli.processes.antibiotics.pbp_binding import PBPBinding
@@ -89,6 +90,7 @@ process_registry.register(Aggregator.name, Aggregator)
 process_registry.register(Lysis.name, Lysis)
 process_registry.register(LocalField.name, LocalField)
 process_registry.register(FieldTimeline.name, FieldTimeline)
+process_registry.register(ExchangeData.name, ExchangeData)
 
 # auxiliary processes
 process_registry.register(Chemostat.name, Chemostat)

--- a/ecoli/processes/__init__.py
+++ b/ecoli/processes/__init__.py
@@ -32,6 +32,7 @@ from ecoli.processes.environment.lysis import Lysis
 from ecoli.processes.environment.local_field import LocalField
 from ecoli.processes.environment.field_timeline import FieldTimeline
 from ecoli.processes.environment.exchange_data import ExchangeData
+from ecoli.processes.environment.media_update import MediaUpdate
 from ecoli.processes.shape import Shape
 from ecoli.processes.antibiotics.cell_wall import CellWall
 from ecoli.processes.antibiotics.pbp_binding import PBPBinding
@@ -91,6 +92,7 @@ process_registry.register(Lysis.name, Lysis)
 process_registry.register(LocalField.name, LocalField)
 process_registry.register(FieldTimeline.name, FieldTimeline)
 process_registry.register(ExchangeData.name, ExchangeData)
+process_registry.register(MediaUpdate.name, MediaUpdate)
 
 # auxiliary processes
 process_registry.register(Chemostat.name, Chemostat)

--- a/ecoli/processes/antibiotics/death.py
+++ b/ecoli/processes/antibiotics/death.py
@@ -314,7 +314,7 @@ class ToyDeath(Composer):
         }
 
 
-def test_death_freeze_state(end_time=10, asserts=True):
+def test_death_freeze_state(end_time=10, asserts=True, return_data=False):
     toy_death_compartment = ToyDeath({}).generate()
 
     init_state = {
@@ -371,14 +371,15 @@ def test_death_freeze_state(end_time=10, asserts=True):
 
         assert expected_saved_states == saved_states
 
-    return saved_states
+    if return_data:
+        return saved_states
 
 
 def plot_death_freeze_state_test():
     out_dir = os.path.join(PROCESS_OUT_DIR, 'death_freeze_state')
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
-    timeseries = test_death_freeze_state(asserts=False)
+    timeseries = test_death_freeze_state(asserts=False, return_data=True)
     plot_settings = {}
     plot_simulation_output(timeseries, plot_settings, out_dir)
 

--- a/ecoli/processes/bulk_timeline.py
+++ b/ecoli/processes/bulk_timeline.py
@@ -62,5 +62,7 @@ class BulkTimelineProcess(Process):
                                         f'its leaves at the same time')
                             curr = curr[subpath]
                 new_timeline.pop(t)
+            # self.timeline is sorted so can break after first time < t
+            break
         self.timeline = new_timeline
         return update

--- a/ecoli/processes/chemotaxis/chemoreceptor_cluster.py
+++ b/ecoli/processes/chemotaxis/chemoreceptor_cluster.py
@@ -287,7 +287,7 @@ def get_brownian_ligand_timeline(
         'speed': speed})
 
 
-def test_receptor(timeline=get_pulse_timeline()):
+def test_receptor(timeline=get_pulse_timeline(), return_data=False):
     ligand = 'MeAsp'
 
     # initialize process
@@ -300,7 +300,9 @@ def test_receptor(timeline=get_pulse_timeline()):
     experiment_settings = {
         'timeline': {
             'timeline': timeline}}
-    return simulate_process(receptor, experiment_settings)
+    data = simulate_process(receptor, experiment_settings)
+    if return_data:
+        return data
 
 
 def main():
@@ -309,7 +311,7 @@ def main():
         os.makedirs(out_dir)
 
     timeline = get_pulse_timeline()
-    timeseries = test_receptor(timeline)
+    timeseries = test_receptor(timeline, return_data=True)
     plot_receptor_output(timeseries, {}, out_dir, 'pulse')
 
     exponential_random_config = {

--- a/ecoli/processes/chemotaxis/coarse_motor.py
+++ b/ecoli/processes/chemotaxis/coarse_motor.py
@@ -196,7 +196,7 @@ def run():
     return [thrust, torque]
 
 
-def test_variable_receptor():
+def test_variable_receptor(return_data=False):
     motor = MotorActivity()
     state = motor.default_state()
     timestep = 1
@@ -221,12 +221,13 @@ def test_variable_receptor():
     # check ccw_to_cw bias is strictly increasing with increased receptor activity
     assert all(i <= j for i, j in zip(ccw_to_cw_vec, ccw_to_cw_vec[1:]))
 
-    return {
-        'chemoreceptor_activity': chemoreceptor_activity,
-        'CheY_P': CheY_P_vec,
-        'ccw_motor_bias': ccw_motor_bias_vec,
-        'ccw_to_cw': ccw_to_cw_vec,
-        'motile_state': motile_state_vec}
+    if return_data:
+        return {
+            'chemoreceptor_activity': chemoreceptor_activity,
+            'CheY_P': CheY_P_vec,
+            'ccw_motor_bias': ccw_motor_bias_vec,
+            'ccw_to_cw': ccw_to_cw_vec,
+            'motile_state': motile_state_vec}
 
 
 def main():
@@ -234,7 +235,7 @@ def main():
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    output2 = test_variable_receptor()
+    output2 = test_variable_receptor(return_data=True)
     plot_variable_receptor(output2, out_dir)
 
 

--- a/ecoli/processes/chemotaxis/flagella_motor.py
+++ b/ecoli/processes/chemotaxis/flagella_motor.py
@@ -345,7 +345,7 @@ def get_chemoreceptor_activity_timeline(
     return timeline
 
 
-def test_variable_flagella(out_dir='out'):
+def test_variable_flagella(out_dir='out', return_data=False):
     total_time = 30
     time_step = 0.01
     initial_flagella = 2
@@ -372,7 +372,8 @@ def test_variable_flagella(out_dir='out'):
             'time_step': time_step}}
     raw_data = simulate_process(process, settings)
 
-    return raw_data
+    if return_data:
+        return raw_data
 
 
 def main():
@@ -380,7 +381,7 @@ def main():
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    data = test_variable_flagella(out_dir)
+    data = test_variable_flagella(out_dir, return_data=True)
 
     # plot
     plot_settings = {}

--- a/ecoli/processes/environment/derive_globals.py
+++ b/ecoli/processes/environment/derive_globals.py
@@ -147,7 +147,7 @@ def get_default_global_state():
             'mmol_to_counts': mmol_to_counts.to('L/mmol')}}
 
 
-def test_deriver(total_time=10):
+def test_deriver(total_time=10, return_data=False):
 
     growth_rate = 6e-3
 
@@ -183,9 +183,10 @@ def test_deriver(total_time=10):
         # save state
         saved_state[time] = copy.deepcopy(state)
 
-    return saved_state
+    if return_data:
+        return saved_state
 
 
 if __name__ == '__main__':
-    saved_data = test_deriver(100)
+    saved_data = test_deriver(100, return_data=True)
     print(saved_data)

--- a/ecoli/processes/environment/exchange_data.py
+++ b/ecoli/processes/environment/exchange_data.py
@@ -1,0 +1,79 @@
+from ecoli.processes.registries import topology_registry
+from vivarium.core.process import Step
+from vivarium.library.units import units
+
+NAME = 'exchange_data'
+TOPOLOGY = {
+    'boundary': ('boundary',),
+    'environment': ('environment',),
+    'first_update': ('first_update', 'exchange_data')
+}
+topology_registry.register(NAME, TOPOLOGY)
+
+class ExchangeData(Step):
+    """
+    Update environment concentrations and metabolism exchange constraints.
+    """
+    name = NAME
+    topology = TOPOLOGY
+    defaults = {
+        'exchange_data_from_concentrations': lambda _: (set(), set()),
+        'environment_molecules': [],
+        'saved_media': {},
+        'time_step': 1,
+    }
+
+    def __init__(self, parameters=None):
+        super().__init__(parameters)
+        self.exchange_data_from_concentrations = self.parameters[
+            'exchange_data_from_concentrations']
+        self.environment_molecules = self.parameters['environment_molecules']
+        self.saved_media = self.parameters['saved_media']
+        
+    def ports_schema(self):
+        return {
+            'boundary': {
+                'external': {
+                    '*': {'_default': 0 * units.mM}
+                }
+            },
+            'environment': {
+                'media_id': {'_default': ''},
+                'exchange_data': {
+                    'constrained': {'_default': {}, '_updater': 'set'},
+                    'unconstrained': {'_default': set(), '_updater': 'set'}
+                }
+            },
+            'first_update': {
+                '_default': True,
+                '_updater': 'set',
+                '_divider': {'divider': 'set_value',
+                    'config': {'value': True}}},
+        }
+    
+    def next_update(self, timestep, states):
+        if states['first_update']:
+            return {'first_update': False}
+
+        env_concs = self.saved_media[states['environment']['media_id']]
+        conc_update = {}
+        # Calculate concentration delta to get from environment specified
+        # by old media ID to the one specified by the current media ID
+        for mol, conc in env_concs.items():
+            conc_update[mol] = conc * units.mM - states['boundary']['external'][mol]
+
+        # Set exchange constraints for metabolism
+        exchange_data = self.exchange_data_from_concentrations(env_concs)
+        unconstrained = exchange_data['importUnconstrainedExchangeMolecules']
+        constrained = exchange_data['importConstrainedExchangeMolecules']
+        return {
+            'boundary': {
+                'external': conc_update
+            },
+            'environment': {
+                'exchange_data': {
+                    'constrained': constrained,
+                    'unconstrained': list(unconstrained)
+                }
+            }
+        }

--- a/ecoli/processes/environment/lysis.py
+++ b/ecoli/processes/environment/lysis.py
@@ -287,7 +287,8 @@ def test_lysis(
         emit_step=1,
         bounds=[25, 25] * units.um,
         n_bins=[5, 5],
-        uptake_rate_max=25
+        uptake_rate_max=25,
+        return_data=False
 ):
     from ecoli.composites.environment.lattice import Lattice
 
@@ -360,7 +361,9 @@ def test_lysis(
         emit_step=emit_step)
     sim.update(total_time)
     data = sim.emitter.get_data_unitless()
-    return data
+
+    if return_data:
+        return data
 
 
 def main():
@@ -377,6 +380,7 @@ def main():
         emit_step=10,
         bounds=bounds,
         n_bins=[11, 11],
+        return_data=True
     )
 
     # format the data for plot_snapshots

--- a/ecoli/processes/environment/media_update.py
+++ b/ecoli/processes/environment/media_update.py
@@ -1,0 +1,60 @@
+from ecoli.processes.registries import topology_registry
+from vivarium.core.process import Step
+from vivarium.library.units import units
+
+NAME = 'media_update'
+TOPOLOGY = {
+    'boundary': ('boundary',),
+    'environment': ('environment',),
+    'first_update': ('first_update', 'media_update')
+}
+topology_registry.register(NAME, TOPOLOGY)
+
+class MediaUpdate(Step):
+    """
+    Update environment concentrations according to current media ID.
+    """
+    name = NAME
+    topology = TOPOLOGY
+    defaults = {
+        'saved_media': {},
+        'time_step': 1,
+    }
+
+    def __init__(self, parameters=None):
+        super().__init__(parameters)
+        self.saved_media = self.parameters['saved_media']
+        
+    def ports_schema(self):
+        return {
+            'boundary': {
+                'external': {
+                    '*': {'_default': 0 * units.mM}
+                }
+            },
+            'environment': {
+                'media_id': {'_default': ''}
+            },
+            'first_update': {
+                '_default': True,
+                '_updater': 'set',
+                '_divider': {'divider': 'set_value',
+                    'config': {'value': True}}},
+        }
+    
+    def next_update(self, timestep, states):
+        if states['first_update']:
+            return {'first_update': False}
+
+        env_concs = self.saved_media[states['environment']['media_id']]
+        conc_update = {}
+        # Calculate concentration delta to get from environment specified
+        # by old media ID to the one specified by the current media ID
+        for mol, conc in env_concs.items():
+            conc_update[mol] = conc * units.mM - states['boundary']['external'][mol]
+
+        return {
+            'boundary': {
+                'external': conc_update
+            }
+        }

--- a/ecoli/processes/environment/media_update.py
+++ b/ecoli/processes/environment/media_update.py
@@ -1,3 +1,4 @@
+import numpy as np
 from ecoli.processes.registries import topology_registry
 from vivarium.core.process import Step
 from vivarium.library.units import units
@@ -51,7 +52,11 @@ class MediaUpdate(Step):
         # Calculate concentration delta to get from environment specified
         # by old media ID to the one specified by the current media ID
         for mol, conc in env_concs.items():
-            conc_update[mol] = conc * units.mM - states['boundary']['external'][mol]
+            diff = conc * units.mM - states['boundary']['external'][mol]
+            # Arithmetic with np.inf gets messy
+            if np.isnan(diff):
+                diff = 0 * units.mM
+            conc_update[mol] = diff
 
         return {
             'boundary': {

--- a/ecoli/processes/environment/multibody_physics.py
+++ b/ecoli/processes/environment/multibody_physics.py
@@ -348,7 +348,7 @@ class InvokeUpdate(object):
         return self.update
 
 # tests and simulations
-def test_multibody(n_agents=1, time=10):
+def test_multibody(n_agents=1, time=10, return_data=False):
     agent_ids = [
         str(agent_id)
         for agent_id in range(n_agents)]
@@ -369,7 +369,9 @@ def test_multibody(n_agents=1, time=10):
         'timestep': 1,
         'total_time': time,
         'return_raw_data': True}
-    return simulate_experiment(experiment, settings)
+    data = simulate_experiment(experiment, settings)
+    if return_data:
+        return data
 
 
 def test_growth_division(
@@ -380,6 +382,7 @@ def test_growth_division(
         total_time=10,
         timestep=1,
         experiment_settings=None,
+        return_data=False
 ):
     if not experiment_settings:
         experiment_settings = {}
@@ -460,7 +463,8 @@ def test_growth_division(
         experiment._send_updates(invoked_update)
 
     experiment.end()
-    return experiment.emitter.get_data_unitless()
+    if return_data:
+        return experiment.emitter.get_data_unitless()
 
 
 def run_growth_division(
@@ -495,7 +499,8 @@ def run_growth_division(
         growth_rate_noise=0.001,
         division_volume=volume_from_length(4, 1) * units.fL,
         total_time=100,
-        experiment_settings=experiment_settings)
+        experiment_settings=experiment_settings,
+        return_data=True)
 
     agents, fields = format_snapshot_data(gd_data)
     return plot_snapshots(

--- a/ecoli/processes/membrane/membrane_potential.py
+++ b/ecoli/processes/membrane/membrane_potential.py
@@ -202,7 +202,7 @@ class MembranePotential(Process):
                 'PMF': PMF}}
 
 
-def test_mem_potential():
+def test_mem_potential(return_data=False):
     """
     test :module: ecoli.processes.membrane.membrane_potential.MembranePotential
     by running it with changing external Na concentrations.
@@ -219,7 +219,9 @@ def test_mem_potential():
 
     PMF_timeseries = timeseries['membrane']['PMF']
     assert PMF_timeseries[-1] > PMF_timeseries[2]
-    return timeseries
+
+    if return_data:
+        return timeseries
 
 
 def main():
@@ -227,7 +229,7 @@ def main():
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    timeseries = test_mem_potential()
+    timeseries = test_mem_potential(return_data=True)
     settings = {
         'remove_first_timestep': True
     }

--- a/ecoli/processes/metabolism.py
+++ b/ecoli/processes/metabolism.py
@@ -74,7 +74,6 @@ class Metabolism(Step):
         'aa_targets_not_updated': set(),
         'import_constraint_threshold': 0,
         'exchange_molecules': [],
-        'exchange_data_from_concentrations': lambda _: (set(), set()),
         'current_timeline': None,
         'media_id': 'minimal',
         'imports': {},
@@ -107,8 +106,6 @@ class Metabolism(Step):
 
         # Use information from the environment and sim
         self.get_import_constraints = self.parameters['get_import_constraints']
-        self.exchange_data_from_concentrations = self.parameters[
-            'exchange_data_from_concentrations']
         self.nutrientToDoublingTime = self.parameters['nutrientToDoublingTime']
         self.use_trna_charging = self.parameters['use_trna_charging']
         self.include_ppgpp = self.parameters['include_ppgpp']
@@ -224,6 +221,10 @@ class Metabolism(Step):
                 'exchange': {
                     str(element): {'_default': 0}
                     for element in self.environment_molecules},
+                'exchange_data': {
+                    'unconstrained': {'_default': {}},
+                    'constrained': {'_default': set()}
+                }
             },
 
             'boundary': {
@@ -361,15 +362,6 @@ class Metabolism(Step):
         cell_mass = states['listeners']['mass']['cell_mass'] * units.fg
         dry_mass = states['listeners']['mass']['dry_mass'] * units.fg
 
-        # Get environment updates
-        current_media_id = states['environment']['media_id']
-        # Get raw concentrations in mM
-        env_concs = {mol: states['boundary']['external'][mol].to('mM').magnitude
-            for mol in self.environment_molecules}
-        exchange_data = self.exchange_data_from_concentrations(env_concs)
-        unconstrained = exchange_data['importUnconstrainedExchangeMolecules']
-        constrained = exchange_data['importConstrainedExchangeMolecules']
-
         # Calculate state values
         cellVolume = cell_mass / self.cellDensity
         counts_to_molar = (1 / (self.nAvogadro * cellVolume)
@@ -379,8 +371,14 @@ class Metabolism(Step):
         # concentration (M) basis
         coefficient = (dry_mass / cell_mass * self.cellDensity
             * timestep * units.s)
+        
+        # Get exchange constraints
+        unconstrained = set(states['environment']['exchange_data'][
+            'unconstrained'])
+        constrained = states['environment']['exchange_data']['constrained']
 
-        ## Determine updates to concentrations depending on the current state
+        # Determine updates to concentrations depending on the current state
+        current_media_id = states['environment']['media_id']
         doubling_time = self.nutrientToDoublingTime.get(
             current_media_id, self.nutrientToDoublingTime[self.media_id])        
         if self.include_ppgpp:

--- a/ecoli/processes/metabolism.py
+++ b/ecoli/processes/metabolism.py
@@ -842,7 +842,7 @@ class FluxBalanceAnalysisModel(object):
             current_media_id, unconstrained, constrained, conc_updates,
         )
         self.fba.update_homeostatic_targets(objective)
-        self.homeostatic_objective = objective
+        self.homeostatic_objective = {**self.homeostatic_objective, **objective}
 
         # Internal concentrations
         metabolite_conc = counts_to_molar * metabolite_counts

--- a/ecoli/processes/metabolism_redux.py
+++ b/ecoli/processes/metabolism_redux.py
@@ -793,7 +793,8 @@ class NetworkFlowModel:
             constr.append(v[self.maintenance_idx] >= ngam_target)
         # If enzymes not present, constrain rxn flux to 0
         if binary_kinetic_idx is not None:
-            constr.append(v[binary_kinetic_idx] == 0)
+            if len(binary_kinetic_idx) > 0:
+                constr.append(v[binary_kinetic_idx] == 0)
         # TODO (Cyrus) - make this a parameter
         constr.extend([v >= 0, v <= upper_flux_bound, e >= 0, e <= upper_flux_bound])
 

--- a/ecoli/processes/metabolism_redux.py
+++ b/ecoli/processes/metabolism_redux.py
@@ -57,7 +57,6 @@ class MetabolismRedux(Step):
         'imports': {},
         'concentration_updates': None,
         'maintenance_reaction': {},
-        'get_import_constraints': lambda u, c, p: (u, c, []),
         'nutrient_to_doubling_time': {},
         'use_trna_charging': False,
         'include_ppgpp': False,
@@ -65,7 +64,6 @@ class MetabolismRedux(Step):
         'aa_targets_not_updated': set(),
         'import_constraint_threshold': 0,
         'exchange_molecules': [],
-        'exchange_data_from_concentrations': lambda _: (set(), set()),
         'non_growth_associated_maintenance': 8.39 * units.mmol / (units.g * units.h),
         'avogadro': 6.02214076e+23 / units.mol,
         'cell_density': 1100 * units.g / units.L,
@@ -94,9 +92,6 @@ class MetabolismRedux(Step):
         super().__init__(parameters)
 
         # Use information from the environment and sim
-        self.get_import_constraints = self.parameters['get_import_constraints']
-        self.exchange_data_from_concentrations = self.parameters[
-            'exchange_data_from_concentrations']
         self.nutrient_to_doubling_time = self.parameters['nutrient_to_doubling_time']
         self.use_trna_charging = self.parameters['use_trna_charging']
         self.include_ppgpp = self.parameters['include_ppgpp']
@@ -106,8 +101,6 @@ class MetabolismRedux(Step):
         self.media_id = self.parameters['media_id']
         self.exchange_molecules = self.parameters[
             'exchange_molecules']
-        self.environment_molecules = sorted(
-            [mol[:-3] for mol in self.exchange_molecules])
         self.aa_names = self.parameters['aa_names']
         self.aa_targets_not_updated = self.parameters['aa_targets_not_updated']
 
@@ -125,30 +118,37 @@ class MetabolismRedux(Step):
 
         self.metabolite_names = sorted(list(self.metabolite_names))
         self.reaction_names = list(stoich_dict.keys())
-        n_metabolites = len(self.metabolite_names)
-        n_reactions = len(self.reaction_names)
 
         metabolites_idx = {species: i for i, species in enumerate(self.metabolite_names)}
-
-        # Convert stoichiometric dictionary to array
-        self.stoichiometry = np.zeros((n_metabolites, n_reactions), dtype=np.int8)
 
         # Get indices of catalysts for each reaction
         reaction_catalysts = self.parameters['reaction_catalysts']
         self.catalyst_ids = self.parameters['catalyst_ids']
         catalyst_idx = {catalyst: i for i, catalyst in enumerate(self.catalyst_ids)}
 
-        self.catalyzed_rxn_enzymes_idx = []
-
-        # Create stoichiometry matrix and enzyme catalyzed reaction index
-        for col_idx, (reaction, stoich) in enumerate(stoich_dict.items()):
+        # Create stoichiometry matrix (dot reaction fluxes to get
+        # molecule deltas) and catalysis matrix (dot catalyst counts
+        # to get catalyst counts per enzyme-catalyzed reaction)
+        coeffs = []
+        met_ind = []
+        rxn_ind = []
+        catalyst_ind = []
+        catalyzed_rxn_ind = []
+        catalyzed_rxn_idx = 0
+        for rxn_idx, (reaction, stoich) in enumerate(stoich_dict.items()):
             for species, coefficient in stoich.items():
-                i = metabolites_idx[species]
-                self.stoichiometry[i, col_idx] = coefficient
-
+                met_ind.append(metabolites_idx[species])
+                rxn_ind.append(rxn_idx)
+                coeffs.append(coefficient)
             enzyme_idx = [catalyst_idx[catalyst]
                 for catalyst in reaction_catalysts.get(reaction, [])]
-            self.catalyzed_rxn_enzymes_idx.append(enzyme_idx)
+            if len(enzyme_idx) > 1:
+                catalyst_ind.extend(enzyme_idx)
+                catalyzed_rxn_ind.extend([catalyzed_rxn_idx]*len(enzyme_idx))
+                catalyzed_rxn_idx += 1
+        self.stoichiometry = csr_matrix((coeffs, (met_ind, rxn_ind)), dtype=int)
+        self.catalysis_matrix = csr_matrix(([1]*len(catalyst_ind),
+            (catalyzed_rxn_ind, catalyst_ind)), dtype=int)
 
         self.media_id = self.parameters['media_id']
         self.cell_density = self.parameters['cell_density']
@@ -171,8 +171,6 @@ class MetabolismRedux(Step):
         self.get_kinetic_constraints = self.parameters['get_kinetic_constraints']
         self.kinetic_constraint_reactions = self.parameters[
             'kinetic_constraint_reactions']
-        self.nutrient_to_doubling_time = self.parameters[
-            'nutrient_to_doubling_time']
         
         # Include ppGpp concentration target in objective if not handled
         # kinetically in other processes
@@ -318,7 +316,10 @@ class MetabolismRedux(Step):
                     '_updater': 'set'},
                 'exchange': {
                     str(element): {'_default': 0}
-                    for element in self.exchange_molecules
+                    for element in self.exchange_molecules},
+                'exchange_data': {
+                    'unconstrained': {'_default': {}},
+                    'constrained': {'_default': set()}
                 }},
 
             'boundary': {
@@ -408,13 +409,8 @@ class MetabolismRedux(Step):
                 self.kinetic_constraint_substrates, bulk_ids)
             self.aa_idx = bulk_name_to_idx(self.aa_names, bulk_ids)
 
-        # Get raw environment concentrations in mM
-        env_concs = {mol: states['boundary']['external'][mol].to('mM').magnitude
-            for mol in self.environment_molecules}
-        exchange_data = self.exchange_data_from_concentrations(env_concs)
-        unconstrained = exchange_data['importUnconstrainedExchangeMolecules']
-        constrained = exchange_data['importConstrainedExchangeMolecules']
-        
+        unconstrained = states['environment']['exchange_data']['unconstrained']
+        constrained = states['environment']['exchange_data']['constrained']        
         new_allowed_exchange_uptake = set(unconstrained).union(
             constrained.keys())
         new_exchange_molecules = set(self.exchange_molecules).union(
@@ -462,13 +458,10 @@ class MetabolismRedux(Step):
         ngam_target = total_ngam.asNumber()
 
         # binary kinetic targets - sum up enzyme counts for each reaction
-        reaction_catalyst_counts = np.array([sum([current_catalyst_counts[enzyme_idx]
-                                                  for enzyme_idx in enzymes_idx])
-                                             if len(enzymes_idx) > 0 else -1
-                                             for enzymes_idx in self.catalyzed_rxn_enzymes_idx])
+        reaction_catalyst_counts = self.catalysis_matrix.dot(current_catalyst_counts)
         # Get reaction indices whose fluxes should be set to zero
         # because there are no enzymes to catalyze the rxn
-        binary_kinetic_idx = np.where(~reaction_catalyst_counts.astype(np.bool_))
+        binary_kinetic_idx = np.where(reaction_catalyst_counts == 0)[0]
         
         # TODO: Figure out how to handle changing media ID
         

--- a/ecoli/processes/metabolism_redux.py
+++ b/ecoli/processes/metabolism_redux.py
@@ -792,7 +792,7 @@ class NetworkFlowModel:
             constr.append(v[self.maintenance_idx] == total_maintenance)
             constr.append(v[self.maintenance_idx] >= ngam_target)
         # If enzymes not present, constrain rxn flux to 0
-        if binary_kinetic_idx:
+        if binary_kinetic_idx is not None:
             constr.append(v[binary_kinetic_idx] == 0)
         # TODO (Cyrus) - make this a parameter
         constr.extend([v >= 0, v <= upper_flux_bound, e >= 0, e <= upper_flux_bound])

--- a/ecoli/processes/polypeptide_elongation.py
+++ b/ecoli/processes/polypeptide_elongation.py
@@ -626,7 +626,7 @@ class PolypeptideElongation(PartitionedProcess):
         return model_specific and max_time_step
 
 
-def test_polypeptide_elongation():
+def test_polypeptide_elongation(return_data=False):
     def make_elongation_rates(random, base, time_step, variable_elongation=False):
         size = 1
         lengths = time_step * np.full(size, base, dtype=np.int64)
@@ -704,7 +704,8 @@ def test_polypeptide_elongation():
         'topology': TOPOLOGY}
     data = simulate_process(polypep_elong, settings)
 
-    return data, test_config
+    if return_data:
+        return data, test_config
 
 
 def run_plot(data, config):
@@ -729,7 +730,7 @@ def run_plot(data, config):
 
 
 def main():
-    data, config = test_polypeptide_elongation()
+    data, config = test_polypeptide_elongation(return_data=True)
     run_plot(data, config)
 
 

--- a/ecoli/processes/protein_degradation.py
+++ b/ecoli/processes/protein_degradation.py
@@ -133,7 +133,7 @@ class ProteinDegradation(PartitionedProcess):
         return self.raw_degradation_rate * timestep
 
 
-def test_protein_degradation():
+def test_protein_degradation(return_data=False):
     test_config = {
         'raw_degradation_rate': np.array([0.05, 0.08, 0.13, 0.21]),
         'water_id': 'H2O',
@@ -209,7 +209,8 @@ def test_protein_degradation():
 
     print("Passed all tests.")
 
-    return data
+    if return_data:
+        return data
 
 
 if __name__ == "__main__":

--- a/ecoli/processes/rna_interference.py
+++ b/ecoli/processes/rna_interference.py
@@ -137,7 +137,7 @@ class RnaInterference(Process):
         
         return update
 
-def test_rna_interference():
+def test_rna_interference(return_data=False):
     test_config = {
         'time_step': 2,
         'ribosome30S': 'CPLX0-3953[c]',
@@ -198,10 +198,11 @@ def test_rna_interference():
     experiment.update(4)
     data = experiment.emitter.get_data()
 
-    return data, test_config
+    if return_data:
+        return data, test_config
 
 def main():
-    data, config = test_rna_interference()
+    data, config = test_rna_interference(return_data=True)
     print(data)
 
 if __name__ == '__main__':

--- a/ecoli/processes/spatiality/spatial_geometry.py
+++ b/ecoli/processes/spatiality/spatial_geometry.py
@@ -180,7 +180,7 @@ def run_spatial_geometry_process():
     return output
 
 
-def test_spatial_geometry_process():
+def test_spatial_geometry_process(return_data=False):
     """
     Test that the process runs correctly.
 
@@ -189,7 +189,8 @@ def test_spatial_geometry_process():
     output = run_spatial_geometry_process()
     # TODO(vivarium): Add assert statements to ensure correct performance.
 
-    return output
+    if return_data:
+        return output
 
 
 def main():
@@ -199,7 +200,7 @@ def main():
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    output = test_spatial_geometry_process()
+    output = test_spatial_geometry_process(return_data=True)
 
 
 

--- a/ecoli/processes/struct_array_demo.py
+++ b/ecoli/processes/struct_array_demo.py
@@ -205,7 +205,8 @@ def test_struct_array_updater(mode="struct_array",
                               rate_add=0.5,
                               rate_delete=0.2,
                               mean_add=1,
-                              total_time=10):
+                              total_time=10,
+                              return_data=False):
     process_config = {
         'mode': mode,
         'rate_add': rate_add,
@@ -233,7 +234,8 @@ def test_struct_array_updater(mode="struct_array",
 
     print(f'Run in mode "{mode}" took {tock - tick} seconds.')
 
-    return (tock - tick), data
+    if return_data:
+        return (tock - tick), data
 
 
 def main():
@@ -259,7 +261,8 @@ def main():
                                                              rate_add=rate_ratio * rate_delete,
                                                              rate_delete=rate_delete,
                                                              mean_add = 100,
-                                                             total_time=total_time)
+                                                             total_time=total_time,
+                                                             return_data=True)
                 result[k, i, j, 0] = time
 
             # Assertions to make sure data matches across modes: ===============================

--- a/ecoli/processes/transcript_elongation.py
+++ b/ecoli/processes/transcript_elongation.py
@@ -683,6 +683,10 @@ def test_transcript_elongation():
             'unique-update': unique_topo,
             'ecoli-transcript-elongation': TOPOLOGY}}
 
+    # Since unique numpy updater is an class method, internal
+    # deepcopying in vivarium-core causes this warning to appear
+    warnings.filterwarnings("ignore",
+        message="Incompatible schema assignment at ")
     engine = Engine(**settings, initial_state=deepcopy(initial_state))
     engine.run_for(100)
     data = engine.emitter.get_timeseries()

--- a/ecoli/processes/transcript_initiation.py
+++ b/ecoli/processes/transcript_initiation.py
@@ -626,7 +626,7 @@ class TranscriptInitiation(PartitionedProcess):
             self.promoter_init_probs[fixed_mask] = synth_prob / fixed_mask.sum()
 
 
-def test_transcript_initiation():
+def test_transcript_initiation(return_data=False):
     def make_elongation_rates(random, base, time_step, variable_elongation=False):
         size = 9  # number of TUs
         lengths = time_step * np.full(size, base, dtype=np.int64)
@@ -824,7 +824,8 @@ def test_transcript_initiation():
     assert (RNA_synth_prob_test.pvalue > 0.05), ("Distribution of RNA types synthesized does"
                                                  "not (approximately) match values set by media")
 
-    return test_config, data_noTF
+    if return_data:
+        return test_config, data_noTF
 
 
 def run_plot(config, data):
@@ -889,7 +890,7 @@ def run_plot(config, data):
 
 
 def main():
-    config, data = test_transcript_initiation()
+    config, data = test_transcript_initiation(return_data=True)
     run_plot(config, data)
 
 

--- a/ecoli/states/wcecoli_state.py
+++ b/ecoli/states/wcecoli_state.py
@@ -31,7 +31,9 @@ def numpy_molecules(states):
     if 'environment' in states:
         if 'exchange_data' in states['environment']:
             states['environment']['exchange_data']['constrained'
-                ] *= units.mmol / (units. g * units.h)
+                ] = {mol: units.mmol / (units. g * units.h) * rate
+                for mol, rate in states['environment']['exchange_data'][
+                    'constrained'].items()}
         else:
             # Load aerobic minimal media exchange data by default
             states['environment']['exchange_data'] = {

--- a/ecoli/states/wcecoli_state.py
+++ b/ecoli/states/wcecoli_state.py
@@ -4,7 +4,7 @@ import numpy as np
 import concurrent.futures
 
 from vivarium.core.serialize import deserialize_value
-from vivarium.library.units import units
+from wholecell.utils import units
 
 def load_states(path):
     with open(path, "r") as states_file:
@@ -28,6 +28,20 @@ def numpy_molecules(states):
             unique_tuples = [tuple(mol) for mol in states['unique'][key]]
             states['unique'][key] = np.array(unique_tuples, dtype=dtypes)
             states['unique'][key].flags.writeable = False
+    if 'environment' in states:
+        if 'exchange_data' in states['environment']:
+            states['environment']['exchange_data']['constrained'
+                ] *= units.mmol / (units. g * units.h)
+        else:
+            # Load aerobic minimal media exchange data by default
+            states['environment']['exchange_data'] = {
+                'unconstrained': ['CL-[p]', 'FE+2[p]', 'FE+3[p]', 'CO+2[p]',
+                    'MG+2[p]', 'NA+[p]', 'CARBON-DIOXIDE[p]',
+                    'OXYGEN-MOLECULE[p]', 'MN+2[p]', 'L-SELENOCYSTEINE[c]',
+                    'K+[p]', 'SULFATE[p]', 'ZN+2[p]', 'CA+2[p]', 'Pi[p]',
+                    'NI+2[p]', 'WATER[p]', 'AMMONIUM[c]'],
+                'constrained': {
+                    'GLC[p]': 20.0 * units.mmol / (units.g * units.h)}}
     return states 
 
 

--- a/migration/composite_mass.py
+++ b/migration/composite_mass.py
@@ -33,6 +33,7 @@ def run_composite_mass_test(total_time=30, operons=True):
         sim.sim_data_path = SIM_DATA_PATH_NO_OPERONS
         sim.initial_state_file = 'migration_no_operons/wcecoli_t0'
     sim.build_ecoli()
+    sim.ecoli.steps['agents']['0']['ecoli-mass-listener'].match_wcecoli = True
 
     # run the composite and save specified states
     sim.run()


### PR DESCRIPTION
- Adds the `BulkTimeline` and `MediaUpdate` processes to change environmental nutrient concentrations in accordance with media ID timelines from `sim_data`
- Adds `ExchangeData` process to update metabolism uptake constraints according to environmental nutrient concentrations
  - Simulations can be run without this (see `fba_redux.json`) if users wish to manually edit uptake constraints ([see here for example](https://github.com/CovertLab/vivarium-ecoli/blob/e562507aa2a69f88cc784cbd4185cb16251b5f52/ecoli/experiments/metabolism_redux_sim.py#L162-L167))
- Adds sparse catalysis matrix to vectorize calculation of catalysts per enzyme-catalyzed reaction in `MetabolismRedux` (also makes stoichiometric matrix sparse from the start).