### PR TITLE
Reaction patch to remove incorrectly parsed reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,6 @@ run the following command in your terminal:
 
     $ pyenv virtualenv 3.10.12 viv-ecoli && pyenv local viv-ecoli
 
-Update `pip`, `setuptools` and `wheel` to avoid issues with these:
-
-    $ pip install --upgrade pip setuptools wheel
-
 Now, install numpy (check `requirements.txt` for the exact version):
 
     $ pip install numpy

--- a/reconstruction/ecoli/flat/metabolic_reactions_removed.tsv
+++ b/reconstruction/ecoli/flat/metabolic_reactions_removed.tsv
@@ -5,3 +5,5 @@
 "RXN-18678"	"Undetermined stoichiometry."
 "TRANS-RXN0-275"	"Reactant and product are identical."
 "TRANS-RXN0-507"	"Reactant and product are identical."
+"RXN-12440" "This is a sum of two reactions. Ascorbate appears on both sides. When it gets parsed as a dict in reconstruction.spreadsheets.JsonReader._decode_row, one of the ascorbate entries gets overwritten, and the reaction becomes unbalanced."
+"R15-RXN"   "Generic reaction that often breaks the model. Need to implement generic reactions first. "


### PR DESCRIPTION
Some EcoCyc reactions have the same metabolite on both sides, resulting in duplicate dict keys when we parse them with reconstruction.spreadsheets.JsonReader._decode_row. One example is https://ecocyc.org/ECOLI/NEW-IMAGE?object=RXN-12440. 

The model can use them to "cheat" since they're not mass balanced, thereby constituting a mass/carbon generating reaction. 

Ideally we'd create some test to see if all reactions are mass balanced at the end, but this'll do for now. 